### PR TITLE
3 run python tests workflow fails on setup pyenv

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -18,6 +18,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install required build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            make build-essential libssl-dev zlib1g-dev \
+            libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
+            libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev \
+            liblzma-dev
+
       - name: setup pyenv
         uses: gabrielfalcao/pyenv-action@v18
         with:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -34,15 +34,6 @@ jobs:
           versions: 3.13.1, 3.12.8
           command: pip install -U pip
 
-      - name: Cache virtual environments
-        uses: actions/cache@v3
-        with:
-          path: |
-            **/.venv
-          key: ${{ runner.os }}-venv-${{ hashFiles('**/requirements.txt', '**/.pythonversion') }}
-          restore-keys: |
-            ${{ runner.os }}-venv-
-
       - name: Install dependencies
         run: |
           # Make the script executable

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -31,7 +31,7 @@ jobs:
         uses: gabrielfalcao/pyenv-action@v18
         with:
           default: 3.13.1
-          versions: 3.13.1, 3.12.8
+          versions: 3.12.8
           command: pip install -U pip
 
       - name: Install dependencies


### PR DESCRIPTION
This pull request updates the Python testing workflow to streamline the environment setup and remove unnecessary and error-prone steps. The key changes involve adding system build dependencies, modifying the Python versions managed by `pyenv`, and removing the virtual environment caching step.

### Workflow updates:

* **Added system build dependencies**: Introduced a step to install essential build tools and libraries required for Python builds, such as `make`, `libssl-dev`, and others. (`.github/workflows/python-tests.yml`, [.github/workflows/python-tests.ymlR21-L36](diffhunk://#diff-207f09dfa0bc604a684631a1c78be7d9aa00f9a6c778eec30afa287990be3da1R21-L36))
* **Modified `pyenv` configuration**: Updated the `pyenv` setup to manage only Python 3.12.8, removing version 3.13.1 from the configuration. (`.github/workflows/python-tests.yml`, [.github/workflows/python-tests.ymlR21-L36](diffhunk://#diff-207f09dfa0bc604a684631a1c78be7d9aa00f9a6c778eec30afa287990be3da1R21-L36))
* **Removed virtual environment caching**: Eliminated the caching of virtual environments to simplify the workflow and avoid potential cache-related issues. (`.github/workflows/python-tests.yml`, [.github/workflows/python-tests.ymlR21-L36](diffhunk://#diff-207f09dfa0bc604a684631a1c78be7d9aa00f9a6c778eec30afa287990be3da1R21-L36))