### PR TITLE
Update Dockerfiles to use cache for pip installations

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install Python dependencies
 COPY ./backend/requirements.txt .
-RUN pip install --user --no-cache-dir -r requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --user -r requirements.txt
 
 
 # Stage 2: Runtime image

--- a/credit_risk_scoring/Dockerfile
+++ b/credit_risk_scoring/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install Python dependencies
 COPY ./credit_risk_scoring/requirements.txt .
-RUN pip install --user --no-cache-dir -r requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --user -r requirements.txt
 
 
 # Stage 2: Runtime image

--- a/fraud_network_detection/Dockerfile
+++ b/fraud_network_detection/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install Python dependencies
 COPY ./fraud_network_detection/requirements.txt .
-RUN pip install --user --no-cache-dir -r requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --user -r requirements.txt
 
 
 # Stage 2: Runtime image

--- a/transaction_anomaly_detection/Dockerfile
+++ b/transaction_anomaly_detection/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install Python dependencies
 COPY ./transaction_anomaly_detection/requirements.txt .
-RUN pip install --user --no-cache-dir -r requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --user -r requirements.txt
 
 
 # Stage 2: Runtime image


### PR DESCRIPTION
This pull request updates the Dockerfiles across multiple services to improve the efficiency of Python dependency installation by leveraging a build cache for `pip`. The changes aim to reduce redundant downloads and speed up builds.

Changes to Dockerfiles:

* [`backend/Dockerfile`](diffhunk://#diff-fed51f49a9f26cb93cc870efdc9419d425b9422354ae41bb651c3333c8bff486L13-R14): Updated the `RUN` command to use a `--mount=type=cache` option for caching `pip` downloads during dependency installation.
* [`credit_risk_scoring/Dockerfile`](diffhunk://#diff-961c2efe467c20286e78bbbb1e7ee85c54ff5f0766a731f8c36445ed29b52cf1L13-R14): Applied the same caching mechanism to the `pip` installation step.
* [`fraud_network_detection/Dockerfile`](diffhunk://#diff-b2c1b792b33e7ea0da7cf2dba2d6618ac333d33d28b8f88e3db82d95e571cbd5L13-R14): Modified the `RUN` command to include the `--mount=type=cache` option for `pip`.
* [`transaction_anomaly_detection/Dockerfile`](diffhunk://#diff-12c30b1cb844a47c9cf6b1087859669f79ee8bf955dc5b44c015d0930189611cL13-R14): Updated the `pip` installation step to use a cache for improved build efficiency.